### PR TITLE
Allow async exclusion

### DIFF
--- a/minit.php
+++ b/minit.php
@@ -294,11 +294,11 @@ class Minit {
 			return;
 
 		$base_url = site_url();
+		$minit_exclude = (array) apply_filters( 'minit-exclude-js', array() );
 
 		foreach ( $wp_scripts->queue as $handle ) {
 
 			// Skip asyncing explicitly excluded script handles
-			$minit_exclude = (array) apply_filters( 'minit-exclude-js', array() );
 			if ( in_array( $handle, $minit_exclude ) ) {
 				continue;
 			}


### PR DESCRIPTION
Basically just skips script handles from being added to async queue if they're present in the `minit-exclude-js` filter.

Before this, **all** external scripts were unconditionally being 'asynced', which might not be **always** wanted.

I've had other external scripts enqueued (think ad-servers and/or similar stuff that must not be asynced
due to `document.write` usage for example) and having them 'asynced' broke them.

This was just a quick fix to get back some control over 'asyncing'. It might even help fix #21 (or at least fix one part of the problem).

If there's a better way to handle this (skip enqueued external scripts from being asynced), I'm all ears...

P.S.
Kudos and many thanks for what you've done with this plugin so far. It's great!
