### PR TITLE
Fixed inline styles adding

### DIFF
--- a/minit.php
+++ b/minit.php
@@ -193,12 +193,16 @@ class Minit {
 
 					$inline_styles = $object->get_data( $script, 'after' );
 
-					foreach ( $inline_styles as $inline_style ) {
+					if ( ! empty( $inline_styles ) ) {
+
+						foreach ( $inline_styles as $inline_style ) {
 						
-						if ( ! empty( $inline_style ) )
 							$object->add_inline_style( 'minit-' . $cache_ver, $inline_style );
 
+						}
+
 					}
+
 				}
 
 				break;


### PR DESCRIPTION
`WP_Styles::get_data` returns an array containing all the inline styles for the stylesheet.
Loop through these and add all of them, because `WP_Styles::add_inline_style` takes a string

Before fixing this, I got an error saying `Array to string conversion in /srv/www/wordpress-default/wp-includes/class.wp-styles.php on line 141`
