### PR TITLE
Rewrite of get_asset_relative_path() to do str_replace instead on several paths

### DIFF
--- a/include/minit-assets.php
+++ b/include/minit-assets.php
@@ -276,5 +276,24 @@ abstract class Minit_Assets {
 		return $full_path;
 	}
 
+	/**
+	 * Filters out the ../ in URLs
+	 *
+	 * @param string $url A possible ugly URL
+	 *
+	 * @return string A nice looking URL
+	 */
+	protected function canonicalize( $url ) {
+		$url = explode( '/', $url );
+		$keys    = array_keys( $url, '..' );
+
+		foreach ( $keys as $keypos => $key ) {
+		    array_splice( $url, $key - ( $keypos * 2 + 1 ), 2 );
+		}
+
+		$url = implode( '/', $url );
+
+		return $url;
+	}
 
 }

--- a/include/minit-assets.php
+++ b/include/minit-assets.php
@@ -223,15 +223,12 @@ abstract class Minit_Assets {
 			return false;
 
 		$full_path = false;
+		//URL in WordPress folder
 		if ( '/' === $item_url[0] ) {
-			// Get the trailing part of the local URL
 			$full_path = ABSPATH . $item_url;
 		}
 		else {
-			$full_path = str_replace( WPMU_PLUGIN_URL, WPMU_PLUGIN_DIR, $item_url );
-			$full_path = str_replace( plugins_url(), WP_PLUGIN_DIR, $full_path );
-			$full_path = str_replace( get_theme_root_uri(), get_theme_root(), $full_path );
-			$full_path = str_replace( content_url(), WP_CONTENT_DIR, $full_path );
+			$full_path = $this->url_to_path( $item_url );
 		}
 
 		if ( $full_path && file_exists( $full_path ) )
@@ -261,6 +258,22 @@ abstract class Minit_Assets {
 			return set_transient( $key, $value, $ttl );
 		}
 
+	}
+
+	/**
+	 * Return the server path of a given URL.
+	 *
+	 * @param string $url The URL of a file
+	 *
+	 * @return string Full server path of the URL
+	 */
+	protected function url_to_path( $url ) {
+		$full_path = str_replace( WPMU_PLUGIN_URL, WPMU_PLUGIN_DIR, $url );
+		$full_path = str_replace( plugins_url(), WP_PLUGIN_DIR, $full_path );
+		$full_path = str_replace( get_theme_root_uri(), get_theme_root(), $full_path );
+		$full_path = str_replace( content_url(), WP_CONTENT_DIR, $full_path );
+
+		return $full_path;
 	}
 
 

--- a/include/minit-assets.php
+++ b/include/minit-assets.php
@@ -101,7 +101,13 @@ abstract class Minit_Assets {
 				continue;
 			}
 
-			$item = $this->minit_item( file_get_contents( $src ), $handle, $src );
+			$relative_path = $src;
+
+			if ( substr( $relative_path, 0, strlen( $_SERVER['DOCUMENT_ROOT'] )) == $_SERVER['DOCUMENT_ROOT'] ) {
+				$relative_path = substr( $relative_path, strlen( $_SERVER['DOCUMENT_ROOT'] ) );
+			} 
+
+			$item = $this->minit_item( file_get_contents( $src ), $handle, $relative_path );
 
 			$item = apply_filters(
 				'minit-item-' . $this->extension,

--- a/include/minit-css.php
+++ b/include/minit-css.php
@@ -82,9 +82,11 @@ class Minit_Css extends Minit_Assets {
 			return $content;
 
 		// Make all local asset URLs absolute
-		$content = preg_replace(
+		$content = preg_replace_callback(
 				'/url\(["\' ]?+(?!data:|https?:|\/\/)(.*?)["\' ]?\)/i',
-				sprintf( "url('%s/$1')", dirname( $src ) ),
+				function( $matches ) use($src) {
+					return sprintf( "url('%s/%s')", dirname( $src ), $this->canonicalize( $matches[1] ) );
+				},
 				$content
 			);
 
@@ -99,9 +101,11 @@ class Minit_Css extends Minit_Assets {
 			return $content;
 
 		// Make all import asset URLs absolute
-		$content = preg_replace(
+		$content = preg_replace_callback(
 				'/@import\s+(url\()?["\'](?!https?:|\/\/)(.*?)["\'](\)?)/i',
-				sprintf( "@import url('%s/$2')", dirname( $src ) ),
+				function( $matches ) use($src) {
+					return sprintf( "@import url('%s/%s')", dirname( $src ), $this->canonicalize( $matches[2] ) );
+				},
 				$content
 			);
 

--- a/include/minit-css.php
+++ b/include/minit-css.php
@@ -84,8 +84,11 @@ class Minit_Css extends Minit_Assets {
 		// Make all local asset URLs absolute
 		$content = preg_replace_callback(
 				'/url\(["\' ]?+(?!data:|https?:|\/\/)(.*?)["\' ]?\)/i',
-				function( $matches ) use($src) {
-					return sprintf( "url('%s/%s')", dirname( $src ), $this->canonicalize( $matches[1] ) );
+				function( $matches ) use ($src) {
+					return sprintf(
+						"url('%s')",
+						$this->canonicalize( dirname( $src ) . '/' . $matches[1] )
+					);
 				},
 				$content
 			);
@@ -103,8 +106,11 @@ class Minit_Css extends Minit_Assets {
 		// Make all import asset URLs absolute
 		$content = preg_replace_callback(
 				'/@import\s+(url\()?["\'](?!https?:|\/\/)(.*?)["\'](\)?)/i',
-				function( $matches ) use($src) {
-					return sprintf( "@import url('%s/%s')", dirname( $src ), $this->canonicalize( $matches[2] ) );
+				function( $matches ) use ($src) {
+					return sprintf(
+						"@import url('%s')",
+						$this->canonicalize( dirname( $src ) . '/' . $matches[1] )
+					);
 				},
 				$content
 			);

--- a/include/minit-css.php
+++ b/include/minit-css.php
@@ -84,7 +84,7 @@ class Minit_Css extends Minit_Assets {
 		// Make all local asset URLs absolute
 		$content = preg_replace(
 				'/url\(["\' ]?+(?!data:|https?:|\/\/)(.*?)["\' ]?\)/i',
-				sprintf( "url('%s/$1')", $this->handler->base_url . dirname( $src ) ),
+				sprintf( "url('%s/$1')", dirname( $src ) ),
 				$content
 			);
 
@@ -101,7 +101,7 @@ class Minit_Css extends Minit_Assets {
 		// Make all import asset URLs absolute
 		$content = preg_replace(
 				'/@import\s+(url\()?["\'](?!https?:|\/\/)(.*?)["\'](\)?)/i',
-				sprintf( "@import url('%s/$2')", $this->handler->base_url . dirname( $src ) ),
+				sprintf( "@import url('%s/$2')", dirname( $src ) ),
 				$content
 			);
 


### PR DESCRIPTION
Simple str_replace() on the url with paths know seems to work really good. I do hate to use the constants you shouldn't really use.
