### PR TITLE
`[at]import` Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*.stackdump

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.stackdump
+*.stackdump

--- a/github.exe.stackdump
+++ b/github.exe.stackdump
@@ -1,0 +1,1 @@
+Exception: STATUS_ACCESS_VIOLATION at eip=64006084

--- a/github.exe.stackdump
+++ b/github.exe.stackdump
@@ -1,1 +1,0 @@
-Exception: STATUS_ACCESS_VIOLATION at eip=64006084

--- a/minit.php
+++ b/minit.php
@@ -425,7 +425,9 @@ class Minit {
 					$uri = $base_url . dirname( $src ).'/'.$uri;
 				} elseif (($file_parts = pathinfo($uri)) && (!isset($file_parts['extension']) || 'css' !== $file_parts['extension'])) {
 					global $minit_imported_stylesheets;
-					$minit_imported_stylesheets[] = $matches[0];
+					if (!in_array($matches[0], $minit_imported_stylesheets)) {
+						$minit_imported_stylesheets[] = $matches[0];
+					}
 					return;
 				}
 

--- a/minit.php
+++ b/minit.php
@@ -152,8 +152,10 @@ class Minit {
 		}
 
 		global $minit_imported_stylesheets;
-		if ( !empty( $minit_imported_stylesheets ) )
+		if ( !empty( $minit_imported_stylesheets ) && ('css' == $extension)) {
 			array_unshift($done, implode("\n", $minit_imported_stylesheets));
+			unset($minit_imported_stylesheets);
+		}
 
 		if ( empty( $done ) )
 			return $todo;

--- a/minit.php
+++ b/minit.php
@@ -125,9 +125,23 @@ class Minit {
 			if ( ! $src || ! file_exists( ABSPATH . $src ) )
 				continue;
 
+			if (!$content = file_get_contents( ABSPATH . $src )) {
+				continue;
+			}
+
+			if ('css' == $extension) {
+
+				$src = self::get_asset_relative_path(
+					$object->base_url,
+					$object->registered[ $script ]->src
+				);
+
+				$content = self::import_fixer($content, $object->base_url, $src);
+			}
+
 			$script_content = apply_filters(
 					'minit-item-' . $extension,
-					file_get_contents( ABSPATH . $src ),
+					$content,
 					$object,
 					$script
 				);
@@ -136,6 +150,10 @@ class Minit {
 				$done[ $script ] = $script_content;
 
 		}
+
+		global $minit_imported_stylesheets;
+		if ( !empty( $minit_imported_stylesheets ) )
+			array_unshift($done, implode("\n", $minit_imported_stylesheets));
 
 		if ( empty( $done ) )
 			return $todo;
@@ -387,7 +405,45 @@ class Minit {
 
 	}
 
+	static function import_fixer($content, $base_url, $src){
 
+		return preg_replace_callback(
+			"/@import\s?url\(['|\"]?(.+?)['|\"]?\);?/",
+			function($matches) use ($base_url, $src) {
+
+				$uri = $matches[1];
+
+				// In case the URL starts with "//" protocol without schema https(s)
+				if (($pos = strpos($uri, '//')) !== false && $pos == 0) {
+					$uri = (is_ssl() ? 'https:' : 'http:').$uri;
+				}
+
+				// Check if the URI is valid before pre-append the BASE URL
+				if (!filter_var($uri, FILTER_VALIDATE_URL)) {
+					$uri = $base_url . dirname( $src ).'/'.$uri;
+				} elseif (($file_parts = pathinfo($uri)) && (!isset($file_parts['extension']) || 'css' !== $file_parts['extension'])) {
+					global $minit_imported_stylesheets;
+					$minit_imported_stylesheets[] = $matches[0];
+					return;
+				}
+
+				$toc = str_replace('@', '[at]', $matches[0]);
+
+				if (!$content = wp_remote_fopen( $uri )) {
+					// return "\n/* Could not import $toc*/\n";
+					return;
+				}
+
+				// $output = "\n\n/*TOC: file imported : $toc*/\n";
+				$output = "\n".trim($content)."\n";
+
+				// Repeat the function in case the imported file also contains an @imports
+				return self::import_fixer($output, $base_url, $src);
+			},
+			$content
+		);
+
+	}
 }
 
 


### PR DESCRIPTION
Injecting the `@import` stylesheets content after check if its REAL CSS
file, if its not, in case of dynamic stylesheet; like google fonts
`@import url('//fonts.googleapis.com/css?family=Open+Sans:400,300');`,
this code moves the imports to the beginning of the combined code.