### PR TITLE
Adding cache version bump hook

### DIFF
--- a/minit.php
+++ b/minit.php
@@ -40,6 +40,9 @@ class Minit_Plugin {
 		// This action can used to delete all Minit cache files from cron
 		add_action( 'minit-cache-purge-delete', array( $this, 'cache_delete' ) );
 
+		// This action can be used to bump the cache version*
+		add_action( 'minit-cache-version-bump', array( $this, 'cache_bump' ) );
+
 	}
 
 

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,8 @@ Combine CSS files and Javascript files into single file in the correct order. Us
 
 The cache is updated when the wp_enqueue version number changes or when the `Minit_Plugin:cache_bump()` method is fired.
 
+The complete cache can be purged by firing the `Minit_Plugin:cache_bump()` method.
+
 
 ## Screenshots
 

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ The cache is updated when the wp_enqueue version number changes or when the `Min
 
 The complete cache can be purged by firing the `Minit_Plugin:cache_bump()` method.
 
+<a href="https://github.com/kasparsd/minit/wiki/Minit-Extensions">Extensions to add additional functionality are available</a>
 
 ## Screenshots
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Combine CSS files and Javascript files into single file in the correct order. Us
 
 ## Description
 
-TODO
+The cache is updated when the wp_enqueue version number changes or when the `Minit_Plugin:cache_bump()` method is fired.
 
 
 ## Screenshots


### PR DESCRIPTION
Fixes #84

Adds extra hook for allowing plugins to bump the cache version number.

```
do_action( 'minit-cache-version-bump' );
```
