### PR TITLE
Add composer.json (for packagist.org)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "kasparsd/minit",
+    "description": "A WordPress plugin to combine CSS and Javascript files",
+    "homepage": "https://github.com/kasparsd/minit",
+    "keywords": [
+        "WordPress", "plugins", "css", "js", "combine", "minify", "concatenate", "optimization", "performance", "speed"
+    ],
+    "support": {
+        "issues": "https://github.com/kasparsd/minit/issues",
+        "source": "https://github.com/kasparsd/minit"
+    },
+    "license": "GPLv2 or later",
+    "authors": [
+        {
+            "name": "Kaspars Dambis",
+            "email": "hi@kaspars.net",
+            "homepage": "http://kaspars.net"
+        }
+    ],
+    "type": "wordpress-plugin",
+    "require": {
+        "php": ">=5.4.0",
+        "composer/installers": "~1.0"
+    }
+    
+}


### PR DESCRIPTION
We want to add this plugin as a packagist package so we can install it via composer.
using : `composer require kasparsd/minit`

Please note that packagist.org needs to be configured too to add the package (I think you know how to do this because you have a package on there).
Another thing: it seems packagist only add the packages with a release so you will need to make a new release with the composer.json in your repository.