### PR TITLE
Comment out minit_exclude_defaults()

### DIFF
--- a/include/helpers.php
+++ b/include/helpers.php
@@ -55,7 +55,8 @@ function minit_maybe_ssl_url( $url ) {
 
 
 // Exclude handles that are known to cause problems
-add_filter( 'minit-exclude-js', 'minit_exclude_defaults' );
+// Modify the array to your liking and uncomment the next line
+//add_filter( 'minit-exclude-js', 'minit_exclude_defaults' );
 
 function minit_exclude_defaults( $handles ) {
 


### PR DESCRIPTION
As `'this-is-a-handle-of-a-script-you-want-to-exclude'` is an example handle.