### PR TITLE
Fix: exclude conditional CSS and before/after JS from Minit

### DIFF
--- a/include/minit-css.php
+++ b/include/minit-css.php
@@ -126,6 +126,10 @@ class Minit_Css extends Minit_Assets {
 			return false;
 		}
 
+		if ( isset( $this->handler->registered[ $handle ]->extra['conditional'] ) ) {
+			return false;
+		}
+
 		return $content;
 
 	}


### PR DESCRIPTION
Also disable async tags by default because "after" JS can't work with that.