### PR TITLE
For CSS the order is important

### DIFF
--- a/minit.php
+++ b/minit.php
@@ -4,7 +4,7 @@ Plugin Name: Minit
 Plugin URI: https://github.com/kasparsd/minit
 GitHub URI: https://github.com/kasparsd/minit
 Description: Combine JS and CSS files and serve them from the uploads folder.
-Version: 1.4.1
+Version: 1.5.0
 Author: Kaspars Dambis
 Author URI: https://kaspars.net
 */

--- a/src/minit-assets.php
+++ b/src/minit-assets.php
@@ -49,6 +49,9 @@ abstract class Minit_Assets {
 	/**
 	 * Get a cache key for a set of assets for the current request.
 	 *
+	 * TODO: Account for before and after values being included
+	 * in the bundle in case of CSS.
+	 *
 	 * @param  array  $handles List of asset handle strings.
 	 *
 	 * @return string
@@ -61,7 +64,7 @@ abstract class Minit_Assets {
 			'minit_cache_ver-' . $this->file_cache()->version(), // Use a global cache version key to purge cache.
 		);
 
-		// Include individual scripts versions in the cache key
+		// Include individual scripts versions in the cache key.
 		foreach ( $handles as $handle ) {
 			$ver[] = sprintf( '%s-%s', $handle, $this->handler->registered[ $handle ]->ver );
 		}

--- a/src/minit-css.php
+++ b/src/minit-css.php
@@ -55,23 +55,17 @@ class Minit_Css extends Minit_Assets {
 		// Add our Minit style since wp_enqueue_script won't do it at this point
 		$todo[] = self::ASSET_HANDLE;
 
-		// Add inline styles for all minited styles
-		foreach ( $this->done as $script ) {
-			// Can this return an array instead?
-			$inline_styles = $this->handler->get_data( $script, 'after' );
-
-			if ( ! empty( $inline_styles ) ) {
-				$this->handler->add_inline_style(
-					self::ASSET_HANDLE,
-					implode( "\n", $inline_styles )
-				);
-			}
-		}
-
 		return $todo;
 	}
 
 	public function minit_item( $content, $handle, $src ) {
+		// Append all inline styles right after to preserve order.
+		$inline_styles = $this->handler->get_data( $handle, 'after' );
+
+		if ( ! empty( $inline_styles ) ) {
+			$content .= implode( "\n", $inline_styles );
+		}
+
 		if ( empty( $content ) ) {
 			return $content;
 		}


### PR DESCRIPTION
- Adding _all_ `after` styles _after_ the bundle breaks the order of styles so we keep them in the bundle instead.