### PR TITLE
Account for block styles with relative CSS URLs

### DIFF
--- a/minit.php
+++ b/minit.php
@@ -4,7 +4,7 @@ Plugin Name: Minit
 Plugin URI: https://github.com/kasparsd/minit
 GitHub URI: https://github.com/kasparsd/minit
 Description: Combine JS and CSS files and serve them from the uploads folder.
-Version: 1.5.0
+Version: 1.7.0
 Author: Kaspars Dambis
 Author URI: https://kaspars.net
 */

--- a/minit.php
+++ b/minit.php
@@ -4,7 +4,7 @@ Plugin Name: Minit
 Plugin URI: https://github.com/kasparsd/minit
 GitHub URI: https://github.com/kasparsd/minit
 Description: Combine JS and CSS files and serve them from the uploads folder.
-Version: 1.7.0
+Version: 1.6.0
 Author: Kaspars Dambis
 Author URI: https://kaspars.net
 */

--- a/src/minit-assets.php
+++ b/src/minit-assets.php
@@ -111,21 +111,17 @@ abstract class Minit_Assets {
 			// Get the relative URL of the asset.
 			$src = $this->get_asset_relative_path( $handle );
 
-			$item_content = '';
-
 			// Ignore pseudo packages such as jquery which return src as empty string.
-			if ( $src && is_readable( ABSPATH . $src ) ) {
-				$item_content = file_get_contents( ABSPATH . $src );
+			if ( ! empty( $src ) && is_readable( ABSPATH . $src ) ) {
+				$item = $this->minit_item( file_get_contents( ABSPATH . $src ), $handle, $src );
+
+				$done[ $handle ] = apply_filters(
+					'minit-item-' . $this->extension,
+					$item,
+					$this->handler,
+					$handle
+				);
 			}
-
-			$item = $this->minit_item( $item_content, $handle, $src );
-
-			$done[ $handle ] = apply_filters(
-				'minit-item-' . $this->extension,
-				$item,
-				$this->handler,
-				$handle
-			);
 		}
 
 		if ( empty( $done ) ) {

--- a/src/minit-assets.php
+++ b/src/minit-assets.php
@@ -243,27 +243,30 @@ abstract class Minit_Assets {
 			return false;
 		}
 
-		$item_url = $this->handler->registered[ $handle ]->src;
+		if ( ! empty( $this->handler->registered[ $handle ]->src ) ) {
+			$item_url = $this->handler->registered[ $handle ]->src;
 
-		if ( empty( $item_url ) ) {
-			return false;
-		}
+			// Inline block scripts are sometimes relative URLs.
+			if ( 0 === strpos( $item_url, '/' ) ) {
+				return $item_url;
+			}
 
-		// Remove protocol reference from the local base URL
-		$base_url = preg_replace( '/^(https?:)/i', '', $this->handler->base_url );
+			// Remove protocol reference from the local base URL
+			$base_url = preg_replace( '/^(https?:)/i', '', $this->handler->base_url );
 
-		// Check if this is a local asset which we can include
-		$src_parts = explode( $base_url, $item_url );
+			// Check if this is a local asset which we can include
+			$src_parts = explode( $base_url, $item_url );
 
-		if ( empty( $src_parts ) ) {
-			return false;
-		}
+			// Get the trailing part of the local URL
+			if ( ! empty( $src_parts ) ) {
+				return array_pop( $src_parts );
+			}
+		} elseif ( ! empty( $this->handler->registered[ $handle ]->extra[ 'path' ] ) ) {
+			$item_path = $this->handler->registered[ $handle ]->extra[ 'path' ];
 
-		// Get the trailing part of the local URL
-		$maybe_relative = array_pop( $src_parts );
-
-		if ( file_exists( ABSPATH . $maybe_relative ) ) {
-			return $maybe_relative;
+			if ( 0 === strpos( $item_path, ABSPATH ) ) {
+				return str_replace( ABSPATH, '', $item_path );
+			}
 		}
 
 		return false;

--- a/src/minit-assets.php
+++ b/src/minit-assets.php
@@ -108,33 +108,24 @@ abstract class Minit_Assets {
 				continue;
 			}
 
-			// Ignore pseudo packages such as jquery which return src as empty string.
-			if ( empty( $this->handler->registered[ $handle ]->src ) ) {
-				$done[ $handle ] = null;
-
-				continue;
-			}
-
 			// Get the relative URL of the asset.
 			$src = $this->get_asset_relative_path( $handle );
 
-			// Skip if the file is not hosted locally.
-			if ( empty( $src ) || ! file_exists( ABSPATH . $src ) ) {
-				continue;
+			$item_content = '';
+
+			// Ignore pseudo packages such as jquery which return src as empty string.
+			if ( $src && is_readable( ABSPATH . $src ) ) {
+				$item_content = file_get_contents( ABSPATH . $src );
 			}
 
-			$item = $this->minit_item( file_get_contents( ABSPATH . $src ), $handle, $src );
+			$item = $this->minit_item( $item_content, $handle, $src );
 
-			$item = apply_filters(
+			$done[ $handle ] = apply_filters(
 				'minit-item-' . $this->extension,
 				$item,
 				$this->handler,
 				$handle
 			);
-
-			if ( false !== $item ) {
-				$done[ $handle ] = $item;
-			}
 		}
 
 		if ( empty( $done ) ) {


### PR DESCRIPTION
- Remove async JS script loader for external scripts because we can't reliably determine if the script is external.
- Update the asset file path extractor to support paths relative to ABSPATH as used by block assets, for example.