### PR TITLE
feat: pass along queued JS/CSS handles to exclude filter

### DIFF
--- a/minit.php
+++ b/minit.php
@@ -6,7 +6,7 @@
  * GitHub Plugin URI: https://github.com/kasparsd/minit
  * Update URI: https://updates.wpelevator.com/wp-json/update-pilot/v1/plugins
  * Description: Combine JS and CSS files and serve them from the uploads folder.
- * Version: 3.1.0
+ * Version: 3.2.0
  * Author: Kaspars Dambis
  * Author URI: https://kaspars.net
  * Require PHP: 7.4

--- a/readme.md
+++ b/readme.md
@@ -39,11 +39,13 @@ Use the `minit-script-tag-async` filter (legacy name when async was preferred) t
 
 Use the `minit-exclude-js` and `minit-exclude-css` filters to exclude files from the concatenated bundles:
 
-    add_filter( 'minit-exclude-js', function( $handles ) {
+    add_filter( 'minit-exclude-js', function( $handles, $enqueued ) {
         $handles[] = 'jquery';
 
         return $handles;
-    } );
+    }, 10, 2 );
+
+where `$handles` is an array of handles to exclude, and `$enqueued` is an array of all enqueued handles of the given type.
 
 ### Integrate with Block Themes
 

--- a/src/minit-assets.php
+++ b/src/minit-assets.php
@@ -86,7 +86,8 @@ abstract class Minit_Assets {
 		// Allow others to exclude handles from Minit.
 		$excluded_handles = (array) apply_filters(
 			'minit-exclude-' . $this->extension,
-			array()
+			array(),
+			$handles
 		);
 
 		$excluded = array_intersect( $handles, $excluded_handles );


### PR DESCRIPTION
Useful for excluding all core block styles, for example.